### PR TITLE
Improved inet support, including IPv6

### DIFF
--- a/.settings/language.settings.xml
+++ b/.settings/language.settings.xml
@@ -5,7 +5,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuildCommandParser" id="org.eclipse.cdt.managedbuilder.core.GCCBuildCommandParser" keep-relative-paths="false" name="CDT GCC Build Output Parser" parameter="([^/\\\\]*)((g?cc)|([gc]\+\+)|(clang))" prefer-non-shared="true"/>
-			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="-728011232554979242" id="org.eclipse.cdt.managedbuilder.core.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="-119978326511762170" id="org.eclipse.cdt.managedbuilder.core.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+
+### Added
+
+ - #13: IPv6 support.
+
+### Changed
+
+ - #13: Replaced deprecated `inet_addr()` and `inet_ntoa()` functions with more modern equivalents, which support IPv6
+   also.
+   
+
 ## [1.0.1] - 2025-08-01
 
 Bug fix release.

--- a/include/redisx-priv.h
+++ b/include/redisx-priv.h
@@ -15,6 +15,8 @@
 
 #include <pthread.h>
 #include <stdint.h>
+#include <netinet/in.h>
+
 #if WITH_TLS
 #  include <openssl/ssl.h>
 #endif
@@ -117,7 +119,14 @@ typedef struct {
 
   RedisSentinel *sentinel;      ///< Sentinel (high-availability) server configuration.
   RedisCluster *cluster;        ///< Cluster, in which this instance is a member
-  uint32_t addr;                ///< The 32-bit inet address
+
+  int in_family;                ///< AF_INET or AF_INET6
+  union {
+    struct in_addr v4;          ///< IPv4 address
+#if _POSIX_C_SOURCE >= 200112L
+    struct in6_addr v6;         ///< IPv6 address (since POSIX-1.2001)
+#endif
+  } addr;                       ///< IP address
 
   RedisConfig config;
   pthread_mutex_t configLock;

--- a/include/redisx.h
+++ b/include/redisx.h
@@ -27,10 +27,10 @@
 #define REDISX_MINOR_VERSION  0
 
 /// Integer sub version of the release
-#define REDISX_PATCHLEVEL     1
+#define REDISX_PATCHLEVEL     2
 
 /// Additional release information in version, e.g. "-1", or "-rc1".
-#define REDISX_RELEASE_STRING ""
+#define REDISX_RELEASE_STRING "-devel"
 
 
 


### PR DESCRIPTION
- Don't use deprecated `inet_addr()` and `inet_ntoa()` functions
- Work with IPv6 also.