### PR TITLE
fix: set LIB before including config.mk

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -1,7 +1,7 @@
 
-include ../config.mk
-
 LIB ?= ../lib
+
+include ../config.mk
 
 # Flags for measuring test coverage
 # Our own include directory


### PR DESCRIPTION
config.mk sets LIB ?= lib, so the LIB ?= ../lib assignment after the
include was always a no-op. This caused the test linker to search in
lib/ instead of ../lib/ and fail to find libredisx.

I moved LIB ?= ../lib above the include so it wins the ?= race.